### PR TITLE
Add use of dataProvider's in test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,8 @@ All notable changes to `caching` will be documented in this file
 - add use of `josiasmontag/laravel-redis-mock` for redis mocking
 - add test methods to `CacheableTest`
 - optimize Travis CI config & enable code coverage uploading
+
+ 
+## 1.3.2 - 2021-08-19
+- add use of dataProvider in `CacheableTest`
+- refactor `TodaysDateHash` mock test class to `DateHash`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,4 @@ All notable changes to `caching` will be documented in this file
 ## 1.3.2 - 2021-08-19
 - add use of dataProvider in `CacheableTest`
 - refactor `TodaysDateHash` mock test class to `DateHash`
+- refactor test classes into `Assets`, `Unit` & `Feature` namespaces

--- a/src/Traits/Cacheable.php
+++ b/src/Traits/Cacheable.php
@@ -12,6 +12,7 @@ trait Cacheable
     // todo: add method for overwriting cache
     // todo: add get ttl method for seeing how long before expiration
     // todo: remove use of `RedisHelpers`
+    // todo: create new trait that replaces execute with `get()`?
 
     /**
      * @var int Time to live

--- a/tests/Assets/DateHash.php
+++ b/tests/Assets/DateHash.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\Caching\Tests\Mocks;
+namespace Sfneal\Caching\Tests\Assets;
 
 use Sfneal\Caching\Traits\Cacheable;
 

--- a/tests/CacheableTest.php
+++ b/tests/CacheableTest.php
@@ -3,14 +3,14 @@
 namespace Sfneal\Caching\Tests;
 
 use Illuminate\Support\Facades\Cache;
-use Sfneal\Caching\Tests\Mocks\TodaysDateHash;
+use Sfneal\Caching\Tests\Mocks\DateHash;
 
 class CacheableTest extends TestCase
 {
     /** @test */
     public function cache_key_is_correct()
     {
-        $todaysDate = new TodaysDateHash();
+        $todaysDate = new DateHash();
 
         $this->assertNotNull($todaysDate->cacheKey());
         $this->assertIsString($todaysDate->cacheKey());
@@ -19,7 +19,7 @@ class CacheableTest extends TestCase
     /** @test */
     public function values_can_be_cached()
     {
-        $todaysDate = new TodaysDateHash();
+        $todaysDate = new DateHash();
 
         $output = $todaysDate->fetch();
 
@@ -30,7 +30,7 @@ class CacheableTest extends TestCase
     /** @test */
     public function cache_can_be_invalidated()
     {
-        $todaysDate = new TodaysDateHash();
+        $todaysDate = new DateHash();
         $todaysDate->fetch();
 
         $this->assertTrue($todaysDate->isCached());

--- a/tests/CacheableTest.php
+++ b/tests/CacheableTest.php
@@ -9,26 +9,6 @@ use Sfneal\Caching\Tests\Mocks\DateHash;
 class CacheableTest extends TestCase
 {
     /**
-     * Retrieve an array of arguments to pass to `DateHash` constructor.
-     *
-     * @return array[]
-     */
-    public function dateHashParamsProvider(): array
-    {
-        return [
-            [now()->subDay(), 'Y-m-d'],
-            [now()->subDay(), 'm/d/Y'],
-            [now()->subDay(), 'm/d/y'],
-            [now(), 'Y-m-d'],
-            [now(), 'm/d/Y'],
-            [now(), 'm/d/y'],
-            [now()->addDay(), 'Y-m-d'],
-            [now()->addDay(), 'm/d/Y'],
-            [now()->addDay(), 'm/d/y'],
-        ];
-    }
-
-    /**
      * @test
      * @dataProvider dateHashParamsProvider
      * @param Carbon $datetime

--- a/tests/CacheableTest.php
+++ b/tests/CacheableTest.php
@@ -2,8 +2,8 @@
 
 namespace Sfneal\Caching\Tests;
 
+use Illuminate\Support\Facades\Cache;
 use Sfneal\Caching\Tests\Mocks\TodaysDateHash;
-use Sfneal\Helpers\Redis\RedisCache;
 
 class CacheableTest extends TestCase
 {
@@ -24,7 +24,7 @@ class CacheableTest extends TestCase
         $output = $todaysDate->fetch();
 
         $this->assertTrue($todaysDate->isCached());
-        $this->assertEquals(RedisCache::get($todaysDate->cacheKey()), $output);
+        $this->assertEquals(Cache::get($todaysDate->cacheKey()), $output);
     }
 
     /** @test */

--- a/tests/Mocks/DateHash.php
+++ b/tests/Mocks/DateHash.php
@@ -47,6 +47,6 @@ class DateHash
      */
     public function cacheKey(): string
     {
-        return "date-hash:{$this->date}#{$this->format}";
+        return "date-hash:{$this->date}:{$this->format}";
     }
 }

--- a/tests/Mocks/DateHash.php
+++ b/tests/Mocks/DateHash.php
@@ -4,9 +4,14 @@ namespace Sfneal\Caching\Tests\Mocks;
 
 use Sfneal\Caching\Traits\Cacheable;
 
-class TodaysDateHash
+class DateHash
 {
     use Cacheable;
+
+    /**
+     * @var string
+     */
+    private $date;
 
     /**
      * @var string
@@ -16,11 +21,13 @@ class TodaysDateHash
     /**
      * TodaysDateHash constructor.
      *
+     * @param string|null $datetime
      * @param string $format
      */
-    public function __construct(string $format = 'Y-m-d')
+    public function __construct(string $datetime = null, string $format = 'Y-m-d')
     {
         $this->format = $format;
+        $this->date = date($this->format, strtotime($datetime ?? now()));
     }
 
     /**
@@ -30,7 +37,7 @@ class TodaysDateHash
      */
     public function execute(): string
     {
-        return md5(date($this->format));
+        return md5($this->date);
     }
 
     /**
@@ -40,6 +47,6 @@ class TodaysDateHash
      */
     public function cacheKey(): string
     {
-        return "todays-date:{$this->format}";
+        return "date-hash:{$this->date}#{$this->format}";
     }
 }

--- a/tests/Mocks/TodaysDateHash.php
+++ b/tests/Mocks/TodaysDateHash.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Caching\Tests\Mocks;
 
-use Illuminate\Database\Eloquent\Collection;
 use Sfneal\Caching\Traits\Cacheable;
 
 class TodaysDateHash
@@ -27,9 +26,9 @@ class TodaysDateHash
     /**
      * Execute the Action.
      *
-     * @return Collection|int|mixed
+     * @return string
      */
-    public function execute()
+    public function execute(): string
     {
         return md5(date($this->format));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,4 +36,24 @@ class TestCase extends OrchestraTestCase
             RedisMockServiceProvider::class,
         ];
     }
+
+    /**
+     * Retrieve an array of arguments to pass to `DateHash` constructor.
+     *
+     * @return array[]
+     */
+    public function dateHashParamsProvider(): array
+    {
+        return [
+            [now()->subDay(), 'Y-m-d'],
+            [now()->subDay(), 'm/d/Y'],
+            [now()->subDay(), 'm/d/y'],
+            [now(), 'Y-m-d'],
+            [now(), 'm/d/Y'],
+            [now(), 'm/d/y'],
+            [now()->addDay(), 'Y-m-d'],
+            [now()->addDay(), 'm/d/Y'],
+            [now()->addDay(), 'm/d/y'],
+        ];
+    }
 }

--- a/tests/Unit/CacheableTest.php
+++ b/tests/Unit/CacheableTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Sfneal\Caching\Tests;
+namespace Sfneal\Caching\Tests\Unit;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
-use Sfneal\Caching\Tests\Mocks\DateHash;
+use Sfneal\Caching\Tests\Assets\DateHash;
+use Sfneal\Caching\Tests\TestCase;
 
 class CacheableTest extends TestCase
 {


### PR DESCRIPTION
- add use of dataProvider in `CacheableTest`
- refactor `TodaysDateHash` mock test class to `DateHash`
- refactor test classes into `Assets`, `Unit` & `Feature` namespaces