### PR TITLE
Fix `Cacheable::invalidateCache()` methods return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,3 +78,8 @@ All notable changes to `caching` will be documented in this file
 ## 2.0.1 - 2021-08-31
 - add support for sfneal/redis-helper v2.0
 - cut use of removed `RedisCache` methods
+
+
+## 2.1.0 - 2021-09-03
+- fix `Cacheable::invalidateCache()` method to return an array of deleted keys for easier debugging
+- add improved assertions to `CacheInvalidationTest`

--- a/src/Traits/Cacheable.php
+++ b/src/Traits/Cacheable.php
@@ -59,14 +59,11 @@ trait Cacheable
     /**
      * Invalidate the Query Cache for this Query.
      *
-     * @return self
+     * @return array
      */
-    public function invalidateCache(): self
+    public function invalidateCache(): array
     {
-        // todo: refactor to protected method?
-        RedisCache::delete($this->cacheKeyPrefix());
-
-        return $this;
+        return RedisCache::delete($this->cacheKeyPrefix());
     }
 
     /**

--- a/tests/Feature/CacheInvalidationTest.php
+++ b/tests/Feature/CacheInvalidationTest.php
@@ -24,11 +24,9 @@ class CacheInvalidationTest extends TestCase
             $this->assertTrue($conversion->isCached());
         }
 
-        $conversions[0]->invalidateCache();
+        $invalidations = $conversions[0]->invalidateCache();
 
-        foreach ($conversions as $conversion) {
-            $this->assertFalse($conversion->isCached());
-        }
+        $this->assertCacheInvalidated($conversions, $invalidations);
     }
 
     /** @test */
@@ -45,11 +43,9 @@ class CacheInvalidationTest extends TestCase
             $this->assertTrue($conversion->isCached());
         }
 
-        $conversions[0]->invalidateCache();
+        $invalidations = $conversions[0]->invalidateCache();
 
-        foreach ($conversions as $conversion) {
-            $this->assertFalse($conversion->isCached());
-        }
+        $this->assertCacheInvalidated($conversions, $invalidations);
     }
 
     /** @test */
@@ -66,11 +62,9 @@ class CacheInvalidationTest extends TestCase
             $this->assertTrue($conversion->isCached());
         }
 
-        $conversions[0]->invalidateCache();
+        $invalidations = $conversions[0]->invalidateCache();
 
-        foreach ($conversions as $conversion) {
-            $this->assertFalse($conversion->isCached());
-        }
+        $this->assertCacheInvalidated($conversions, $invalidations);
     }
 
     /** @test */
@@ -93,7 +87,28 @@ class CacheInvalidationTest extends TestCase
             $this->assertTrue($conversion->isCached());
         }
 
-        (new Converter)->invalidateCache();
+        $invalidations = (new Converter)->invalidateCache();
+
+        $this->assertCacheInvalidated($conversions, $invalidations);
+    }
+
+    /**
+     * Execute assertions to confirm the cache has been invalidated.
+     *
+     * @param array $conversions
+     * @param $invalidations
+     */
+    public function assertCacheInvalidated(array $conversions, $invalidations): void
+    {
+        $this->assertIsArray($invalidations);
+        $this->assertCount(count($conversions), $invalidations);
+        $this->assertEquals(
+            array_keys($invalidations),
+            collect($conversions)->map(function (Converter $converter) {
+                return $converter->cacheKey();
+            })->toArray()
+        );
+        $this->assertEquals(array_fill(0, count($conversions), 1), array_values($invalidations));
 
         foreach ($conversions as $conversion) {
             $this->assertFalse($conversion->isCached());

--- a/tests/Feature/CacheInvalidationTest.php
+++ b/tests/Feature/CacheInvalidationTest.php
@@ -102,11 +102,21 @@ class CacheInvalidationTest extends TestCase
     {
         $this->assertIsArray($invalidations);
         $this->assertCount(count($conversions), $invalidations);
+
         $this->assertEquals(
-            array_keys($invalidations),
-            collect($conversions)->map(function (Converter $converter) {
-                return $converter->cacheKey();
-            })->toArray()
+            array_values(
+                collect(array_keys($invalidations))
+                    ->sort()
+                    ->toArray()
+            ),
+            array_values(
+                collect($conversions)
+                    ->map(function (Converter $converter) {
+                        return $converter->cacheKey();
+                    })
+                    ->sort()
+                    ->toArray()
+            )
         );
         $this->assertEquals(array_fill(0, count($conversions), 1), array_values($invalidations));
 


### PR DESCRIPTION
- fix `Cacheable::invalidateCache()` method to return an array of deleted keys for easier debugging
- add improved assertions to `CacheInvalidationTest`