### PR TITLE
Add `HasAutoCacheKey` trait for auto generating cache keys

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,7 +19,7 @@ checks:
 
 build:
     environment:
-        php: 8.0.1
+        php: 8.1
     nodes:
         analysis:
             tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,3 +106,7 @@ All notable changes to `caching` will be documented in this file
 - cut support for PHP 7
 - add support for PHP 8
 - cleanup dependency constraints
+
+
+## 4.1.0 - 2024-05-22
+- add `HasAutoCacheKey` trait for auto generating a cache key (removes the need to define a `cacheKey()` method)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false" testdox="true">
   <testsuites>
     <testsuite name="Test Suite">
       <directory>tests</directory>

--- a/src/Traits/HasAutoCacheKey.php
+++ b/src/Traits/HasAutoCacheKey.php
@@ -15,15 +15,16 @@ trait HasAutoCacheKey
     {
         $reflection = (new \ReflectionClass($this));
 
-        $key  = 'auto_' . strtolower(str_replace('\\', '-', $reflection->getName()));
+        $key = 'auto_'.strtolower(str_replace('\\', '-', $reflection->getName()));
 
         if (count($reflection->getProperties())) {
             foreach ($reflection->getProperties() as $property) {
                 if ($property->getName() != 'ttl') {
-                    $key .= ':' . $this->{$property->getName()};
+                    $key .= ':'.$this->{$property->getName()};
                 }
             }
         }
+
         return $key;
     }
 }

--- a/src/Traits/HasAutoCacheKey.php
+++ b/src/Traits/HasAutoCacheKey.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sfneal\Caching\Traits;
+
+trait HasAutoCacheKey
+{
+    use IsCacheable;
+
+    /**
+     * Retrieve the Query cache key.
+     *
+     * @return string
+     */
+    public function cacheKey(): string
+    {
+        $reflection = (new \ReflectionClass($this));
+
+        $key  = 'auto_' . strtolower(str_replace('\\', '-', $reflection->getName()));
+
+        if (count($reflection->getProperties())) {
+            foreach ($reflection->getProperties() as $property) {
+                if ($property->getName() != 'ttl') {
+                    $key .= ':' . $this->{$property->getName()};
+                }
+            }
+        }
+        return $key;
+    }
+}

--- a/tests/Assets/AutoKeyPoundConverter.php
+++ b/tests/Assets/AutoKeyPoundConverter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sfneal\Caching\Tests\Assets;
+
+use Sfneal\Caching\Traits\Cacheable;
+use Sfneal\Caching\Traits\HasAutoCacheKey;
+use Sfneal\Currency\Currency;
+
+class AutoKeyPoundConverter
+{
+    use Cacheable;
+    use HasAutoCacheKey;
+
+    /**
+     * @var int
+     */
+    private $amount;
+
+    /**
+     * EuroConverter constructor.
+     *
+     * @param  int  $amount
+     */
+    public function __construct(int $amount)
+    {
+        $this->amount = $amount;
+    }
+
+    /**
+     * Execute the Query.
+     *
+     * @return string
+     */
+    public function execute(): string
+    {
+        return Currency::pounds($this->amount);
+    }
+}

--- a/tests/Feature/CacheInvalidationTest.php
+++ b/tests/Feature/CacheInvalidationTest.php
@@ -19,7 +19,10 @@ class CacheInvalidationTest extends TestCase
             new EuroConverter(rand(0, 1000)),
         ];
 
+        $conversions[0]->invalidateCache();
+
         foreach ($conversions as $conversion) {
+            $this->assertFalse($conversion->isCached());
             $conversion->fetch();
             $this->assertTrue($conversion->isCached());
         }
@@ -38,7 +41,10 @@ class CacheInvalidationTest extends TestCase
             new PoundConverter(rand(0, 1000)),
         ];
 
+        $conversions[0]->invalidateCache();
+
         foreach ($conversions as $conversion) {
+            $this->assertFalse($conversion->isCached());
             $conversion->fetch();
             $this->assertTrue($conversion->isCached());
         }
@@ -57,7 +63,10 @@ class CacheInvalidationTest extends TestCase
             new DollarConverter(rand(0, 1000)),
         ];
 
+        $conversions[0]->invalidateCache();
+
         foreach ($conversions as $conversion) {
+            $this->assertFalse($conversion->isCached());
             $conversion->fetch();
             $this->assertTrue($conversion->isCached());
         }
@@ -83,6 +92,7 @@ class CacheInvalidationTest extends TestCase
         ];
 
         foreach ($conversions as $conversion) {
+            $this->assertFalse($conversion->isCached());
             $conversion->fetch();
             $this->assertTrue($conversion->isCached());
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Illuminate\Support\Facades\Cache;
 use Lunaweb\RedisMock\Providers\RedisMockServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Sfneal\Caching\Tests\Assets\AutoKeyPoundConverter;
 use Sfneal\Caching\Tests\Assets\DateHash;
 use Sfneal\Caching\Tests\Assets\DollarConverter;
 use Sfneal\Caching\Tests\Assets\EuroConverter;
@@ -72,24 +73,25 @@ class TestCase extends OrchestraTestCase
     public static function cacheablesProvider(): array
     {
         return [
-            [new DateHash(now()->subDay(), 'Y-m-d')],
-            [new DateHash(now()->subDay(), 'm/d/Y')],
-            [new DateHash(now()->subDay(), 'm/d/y')],
-            [new DateHash(now(), 'Y-m-d')],
-            [new DateHash(now(), 'm/d/Y')],
-            [new DateHash(now(), 'm/d/y')],
-            [new DateHash(now()->addDay(), 'Y-m-d')],
-            [new DateHash(now()->addDay(), 'm/d/Y')],
-            [new DateHash(now()->addDay(), 'm/d/y')],
-            [new EuroConverter(rand(0, 1000))],
-            [new EuroConverter(rand(0, 1000))],
-            [new EuroConverter(rand(0, 1000))],
-            [new PoundConverter(rand(0, 1000))],
-            [new PoundConverter(rand(0, 1000))],
-            [new PoundConverter(rand(0, 1000))],
-            [new DollarConverter(rand(0, 1000))],
-            [new DollarConverter(rand(0, 1000))],
-            [new DollarConverter(rand(0, 1000))],
+            'DateHash_1' => [new DateHash(now()->subDay(), 'Y-m-d')],
+            'DateHash_2' => [new DateHash(now()->subDay(), 'm/d/Y')],
+            'DateHash_3' => [new DateHash(now()->subDay(), 'm/d/y')],
+            'DateHash_4' => [new DateHash(now(), 'Y-m-d')],
+            'DateHash_5' => [new DateHash(now(), 'm/d/Y')],
+            'DateHash_6' => [new DateHash(now(), 'm/d/y')],
+            'DateHash_7' => [new DateHash(now()->addDay(), 'Y-m-d')],
+            'DateHash_8' => [new DateHash(now()->addDay(), 'm/d/Y')],
+            'DateHash_9' => [new DateHash(now()->addDay(), 'm/d/y')],
+            'EuroConverter_1' => [new EuroConverter(rand(0, 1000))],
+            'EuroConverter_2' => [new EuroConverter(rand(0, 1000))],
+            'EuroConverter_3' => [new EuroConverter(rand(0, 1000))],
+            'PoundConverter_1' => [new PoundConverter(rand(0, 1000))],
+            'PoundConverter_2' => [new PoundConverter(rand(0, 1000))],
+            'PoundConverter_3' => [new PoundConverter(rand(0, 1000))],
+            'DollarConverter_1' => [new DollarConverter(rand(0, 1000))],
+            'DollarConverter_2' => [new DollarConverter(rand(0, 1000))],
+            'DollarConverter_3' => [new DollarConverter(rand(0, 1000))],
+            'AutoKeyPoundConverter' => [new AutoKeyPoundConverter(rand(0, 1000))],
         ];
     }
 }

--- a/tests/Unit/CacheableTest.php
+++ b/tests/Unit/CacheableTest.php
@@ -27,7 +27,6 @@ class CacheableTest extends TestCase
         $num = rand(0, 1000);
         $cacheable = new AutoKeyPoundConverter($num);
 
-
         $this->assertNotNull($cacheable->cacheKey());
         $this->assertIsString($cacheable->cacheKey());
         $this->assertStringContainsString(
@@ -35,7 +34,7 @@ class CacheableTest extends TestCase
             $cacheable->cacheKey()
         );
         $this->assertEquals(
-            'auto_sfneal-caching-tests-assets-autokeypoundconverter:' . $num,
+            'auto_sfneal-caching-tests-assets-autokeypoundconverter:'.$num,
             $cacheable->cacheKey()
         );
     }

--- a/tests/Unit/CacheableTest.php
+++ b/tests/Unit/CacheableTest.php
@@ -3,6 +3,7 @@
 namespace Sfneal\Caching\Tests\Unit;
 
 use Illuminate\Support\Facades\Cache;
+use Sfneal\Caching\Tests\Assets\AutoKeyPoundConverter;
 use Sfneal\Caching\Tests\TestCase;
 
 class CacheableTest extends TestCase
@@ -18,6 +19,25 @@ class CacheableTest extends TestCase
     {
         $this->assertNotNull($cacheable->cacheKey());
         $this->assertIsString($cacheable->cacheKey());
+    }
+
+    /** @test */
+    public function cache_key_is_correct_auto_generate()
+    {
+        $num = rand(0, 1000);
+        $cacheable = new AutoKeyPoundConverter($num);
+
+
+        $this->assertNotNull($cacheable->cacheKey());
+        $this->assertIsString($cacheable->cacheKey());
+        $this->assertStringContainsString(
+            'auto_sfneal-caching-tests-assets-autokeypoundconverter',
+            $cacheable->cacheKey()
+        );
+        $this->assertEquals(
+            'auto_sfneal-caching-tests-assets-autokeypoundconverter:' . $num,
+            $cacheable->cacheKey()
+        );
     }
 
     /**


### PR DESCRIPTION
- add `HasAutoCacheKey` trait for auto generating a cache key (removes the need to define a `cacheKey()` method)